### PR TITLE
feat: actualizar modelo de categoría para usar tipo de dato string en…

### DIFF
--- a/prisma/migrations/20250329165215_category_family/migration.sql
+++ b/prisma/migrations/20250329165215_category_family/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `family` column on the `Category` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "Category" DROP COLUMN "family",
+ADD COLUMN     "family" TEXT NOT NULL DEFAULT 'OTHER';
+
+-- DropEnum
+DROP TYPE "Family";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,10 +301,9 @@ model ProductImage {
 }
 
 model Category {
-  id String @id @unique @default(uuid())
-
+  id          String  @id @unique @default(uuid())
   name        String  @unique
-  family      Family  @default(CHOCOLAT)
+  family      String  @default("OTHER")
   description String?
   isActive    Boolean @default(true)
 
@@ -313,15 +312,6 @@ model Category {
 
   // Relación con Product
   products Product[] @relation("categoryId")
-}
-
-enum Family {
-  CHOCOLAT // Chocolate
-  DRINK // Drink
-  SPICES // Spices
-  PERSONAL_CARE // Personal Care
-  MERCH // Merchandise
-  OTHER // Other
 }
 
 model ProductVariation {

--- a/src/modules/admin/category/dto/create-category.dto.ts
+++ b/src/modules/admin/category/dto/create-category.dto.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Family } from '@prisma/client';
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsString } from 'class-validator';
 
@@ -23,9 +22,8 @@ export class CreateCategoryDto {
 
   @ApiProperty({
     description: 'Familia de la categoría',
-    example: 'CHOCOLAT',
-    enum: Family
+    example: 'CHOCOLAT'
   })
   @IsString()
-  family: Family;
+  family: string;
 }

--- a/src/modules/admin/category/dto/update-category.dto.ts
+++ b/src/modules/admin/category/dto/update-category.dto.ts
@@ -1,8 +1,7 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
-import { CreateCategoryDto } from './create-category.dto';
-import { IsNotEmpty, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
-import { Family } from '@prisma/client';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { CreateCategoryDto } from './create-category.dto';
 
 export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {
   @ApiProperty({
@@ -27,9 +26,8 @@ export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {
   @ApiProperty({
     description: 'Familia de la categoría',
     example: 'CHOCOLAT',
-    enum: Family,
     required: false
   })
   @IsString()
-  family?: Family;
+  family?: string;
 }

--- a/src/modules/shop/catalog/catalog.service.ts
+++ b/src/modules/shop/catalog/catalog.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Family } from '@prisma/client';
 import { CategoryData, ProductData } from 'src/interfaces';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { handleException } from 'src/utils';
@@ -154,7 +153,7 @@ export class CatalogService {
     const merchProducts = await this.prisma.product.findMany({
       where: {
         category: {
-          family: Family.MERCH
+          family: 'OTHER'
         }
       },
       include: {
@@ -288,7 +287,7 @@ export class CatalogService {
           },
           category: {
             family: {
-              not: Family.MERCH
+              not: 'OTHER'
             }
           }
         },
@@ -347,7 +346,7 @@ export class CatalogService {
           isActive: true,
           category: {
             family: {
-              not: Family.MERCH
+              not: 'OTHER'
             }
           }
         },


### PR DESCRIPTION
This pull request includes several changes to the `Category` model and related files to replace the `Family` enum with a string type. The most important changes involve modifying the database schema, updating the Prisma schema, and adjusting the DTOs and service files accordingly.

### Database Schema Changes:
* [`prisma/migrations/20250329165215_category_family/migration.sql`](diffhunk://#diff-4108f0637db352ca87a52581ffc369444c8f46a4dff39ae381b64f5a2ecf58efR1-R12): Dropped the `family` column and recreated it as a `TEXT` column with a default value of 'OTHER'. Also, dropped the `Family` enum type.

### Prisma Schema Changes:
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL305-R306): Changed the `family` field in the `Category` model from `Family` enum to `String` with a default value of 'OTHER'. Removed the `Family` enum definition. 
### DTO Updates:
* [`src/modules/admin/category/dto/create-category.dto.ts`](diffhunk://#diff-22bf7af37f6a06c21c05848a4863f2ddbdd5f73933f445138b7975fb7687ac54L2): Updated the `CreateCategoryDto` to use a string type for the `family` property instead of the `Family` enum. 
* [`src/modules/admin/category/dto/update-category.dto.ts`](diffhunk://#diff-18e48fb596f6a6027587d732f91dcba02be541765b4f9c40f85096475c45c705L2-R4): Updated the `UpdateCategoryDto` to use a string type for the `family` property instead of the `Family` enum. 

### Service File Adjustments:
* [`src/modules/shop/catalog/catalog.service.ts`](diffhunk://#diff-79ecb824b50cccc4bc769525d63d21d08283da861934ad3c4a9edf6763dcf23bL2): Updated the `CatalogService` to use string values for the `family` property in queries instead of the `Family` enum. 